### PR TITLE
Remove `memPropsToGfx` from `VkMemoryRequirements.toGfx`

### DIFF
--- a/vulkan/source/gfx/vulkan/conv.d
+++ b/vulkan/source/gfx/vulkan/conv.d
@@ -85,7 +85,7 @@ VkImageTiling toVk(in ImageTiling tiling)
 
 MemoryRequirements toGfx(in VkMemoryRequirements mr) {
     return MemoryRequirements(
-        cast(size_t)mr.size, cast(size_t)mr.alignment, memPropsToGfx(mr.memoryTypeBits)
+        cast(size_t)mr.size, cast(size_t)mr.alignment, mr.memoryTypeBits
     );
 }
 


### PR DESCRIPTION
Fixes rtbo/gfx-d#14