### PR TITLE
Add some Vulkan device limits to `DeviceLimits` struct

### DIFF
--- a/gl3/source/gfx/gl3/package.d
+++ b/gl3/source/gfx/gl3/package.d
@@ -196,6 +196,7 @@ final class GlPhysicalDevice : PhysicalDevice
     }
 
     override @property DeviceLimits limits() {
+        // TODO: Query values with `glGet`
         return DeviceLimits.init;
     }
 

--- a/graal/source/gfx/graal/device.d
+++ b/graal/source/gfx/graal/device.d
@@ -34,7 +34,11 @@ struct DeviceFeatures {
 
 struct DeviceLimits
 {
-    size_t linearOptimalGranularity=1;
+    size_t linearOptimalGranularity = 1;
+    size_t maxUniformBufferSize = 16_384; // Minimum guarenteed value of GL_MAX_UNIFORM_BLOCK_SIZE
+    size_t maxDescriptorSetUniformBuffers = 36; // Minimum guarenteed value of GL_MAX_UNIFORM_BUFFER_BINDINGS
+    size_t maxDescriptorSetUniformBuffersDynamic = 12; // Minimum guarenteed value of GL_MAX_VERTEX_UNIFORM_BLOCKS
+    size_t minUniformBufferOffsetAlignment = 1; // Default of GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT
 }
 
 enum DeviceType {

--- a/graal/source/gfx/graal/device.d
+++ b/graal/source/gfx/graal/device.d
@@ -39,6 +39,7 @@ struct DeviceLimits
     size_t maxDescriptorSetStorageBuffers = 24;
     size_t maxDescriptorSetStorageBuffersDynamic = 4;
     size_t minStorageBufferOffsetAlignment = 1;
+    size_t maxPushConstantsSize = 0;
     size_t maxUniformBufferSize = 16_384; // Minimum guarenteed value of GL_MAX_UNIFORM_BLOCK_SIZE
     size_t maxDescriptorSetUniformBuffers = 36; // Minimum guarenteed value of GL_MAX_UNIFORM_BUFFER_BINDINGS
     size_t maxDescriptorSetUniformBuffersDynamic = 12; // Minimum guarenteed value of GL_MAX_VERTEX_UNIFORM_BLOCKS

--- a/graal/source/gfx/graal/device.d
+++ b/graal/source/gfx/graal/device.d
@@ -35,6 +35,10 @@ struct DeviceFeatures {
 struct DeviceLimits
 {
     size_t linearOptimalGranularity = 1;
+    size_t maxStorageBufferSize = 0;
+    size_t maxDescriptorSetStorageBuffers = 24;
+    size_t maxDescriptorSetStorageBuffersDynamic = 4;
+    size_t minStorageBufferOffsetAlignment = 1;
     size_t maxUniformBufferSize = 16_384; // Minimum guarenteed value of GL_MAX_UNIFORM_BLOCK_SIZE
     size_t maxDescriptorSetUniformBuffers = 36; // Minimum guarenteed value of GL_MAX_UNIFORM_BUFFER_BINDINGS
     size_t maxDescriptorSetUniformBuffersDynamic = 12; // Minimum guarenteed value of GL_MAX_VERTEX_UNIFORM_BLOCKS

--- a/vulkan/source/gfx/vulkan/package.d
+++ b/vulkan/source/gfx/vulkan/package.d
@@ -629,11 +629,20 @@ final class VulkanPhysicalDevice : PhysicalDevice
                 .canFind(swapChainDeviceExtension);
         return features;
     }
+    /// See_Also: <a href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceLimits.html">VkPhysicalDeviceLimits</a>
     override @property DeviceLimits limits()
     {
         DeviceLimits limits;
         limits.linearOptimalGranularity =
                 cast(size_t)_vkProps.limits.bufferImageGranularity;
+        limits.maxUniformBufferSize =
+                cast(size_t)_vkProps.limits.maxUniformBufferRange;
+        limits.maxDescriptorSetUniformBuffers =
+                cast(size_t)_vkProps.limits.maxDescriptorSetUniformBuffers;
+        limits.maxDescriptorSetUniformBuffersDynamic =
+                cast(size_t)_vkProps.limits.maxDescriptorSetUniformBuffersDynamic;
+        limits.minUniformBufferOffsetAlignment =
+                cast(size_t)_vkProps.limits.minUniformBufferOffsetAlignment;
         return limits;
     }
 

--- a/vulkan/source/gfx/vulkan/package.d
+++ b/vulkan/source/gfx/vulkan/package.d
@@ -643,6 +643,8 @@ final class VulkanPhysicalDevice : PhysicalDevice
                 cast(size_t)_vkProps.limits.maxDescriptorSetStorageBuffersDynamic;
         limits.minStorageBufferOffsetAlignment =
                 cast(size_t)_vkProps.limits.minStorageBufferOffsetAlignment;
+        limits.maxPushConstantsSize =
+                cast(size_t)_vkProps.limits.maxPushConstantsSize;
         limits.maxUniformBufferSize =
                 cast(size_t)_vkProps.limits.maxUniformBufferRange;
         limits.maxDescriptorSetUniformBuffers =

--- a/vulkan/source/gfx/vulkan/package.d
+++ b/vulkan/source/gfx/vulkan/package.d
@@ -635,6 +635,14 @@ final class VulkanPhysicalDevice : PhysicalDevice
         DeviceLimits limits;
         limits.linearOptimalGranularity =
                 cast(size_t)_vkProps.limits.bufferImageGranularity;
+        limits.maxStorageBufferSize =
+                cast(size_t)_vkProps.limits.maxStorageBufferRange;
+        limits.maxDescriptorSetStorageBuffers =
+                cast(size_t)_vkProps.limits.maxDescriptorSetStorageBuffers;
+        limits.maxDescriptorSetStorageBuffersDynamic =
+                cast(size_t)_vkProps.limits.maxDescriptorSetStorageBuffersDynamic;
+        limits.minStorageBufferOffsetAlignment =
+                cast(size_t)_vkProps.limits.minStorageBufferOffsetAlignment;
         limits.maxUniformBufferSize =
                 cast(size_t)_vkProps.limits.maxUniformBufferRange;
         limits.maxDescriptorSetUniformBuffers =


### PR DESCRIPTION
I've added these values:

- `maxStorageBufferSize`
- `maxDescriptorSetStorageBuffers`
- `maxDescriptorSetStorageBuffersDynamic`
- `minStorageBufferOffsetAlignment`
- `maxPushConstantsSize`
- `maxUniformBufferSize`
- `maxDescriptorSetUniformBuffers`
- `maxDescriptorSetUniformBuffersDynamic`
- `minUniformBufferOffsetAlignment`

The default values I pulled from lower bounds observed in Khronos' OpenGL specifications and the [Vulkan Hardware Database](https://vulkan.gpuinfo.org/listlimits.php?platform=android).